### PR TITLE
Implementing a db key validity check on starting the encrypted fs

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -8,6 +8,8 @@ class ErrorEncryptedFSNotRunning extends ErrorEncryptedFS {}
 
 class ErrorEncryptedFSDestroyed extends ErrorEncryptedFS {}
 
+class ErrorEncryptedFSKey extends ErrorEncryptedFS {}
+
 class ErrorEncryptedFSError extends ErrorEncryptedFS {
   protected _errno: number;
   protected _code: string;
@@ -73,5 +75,6 @@ export {
   ErrorEncryptedFSRunning,
   ErrorEncryptedFSNotRunning,
   ErrorEncryptedFSDestroyed,
+  ErrorEncryptedFSKey,
   ErrorEncryptedFSError,
 };


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->
There needs to be a more explicit way of determining if the db key is valid for the encrypted fs. At the moment, the efs start up continues until it tries to decrypt existing state and cannot because the key is not valid.

To overcome this, a similar pattern to sentinel species will be used. On creation of the efs, we encrypt a known string into the db at the root level. Then on subsequent constructions, we access the string and if we cannot decrypt it then we know that the vault key is invalid and we therefore throw an error. If the string does not exist in the db then we start and put the known string in because we know its a new db.

### Tasks
<!-- List all tasks to be done by this PR. -->
1. [x] Implement the key validity checks
2. [x] Add new testing for the key validity checks

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
